### PR TITLE
chore: adds PR title linting

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,23 @@
+name: PR Validation
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+permissions:
+  contents: read # for checkout
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - uses: aslafy-z/conventional-pr-title-action@v3
+        with:
+          preset: conventional-changelog-eslint
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing
+
+## Commits
+
+We use the `conventional-changelog-eslint` configuration.  While you don't need to ensure that individual commits follow that pattern, you _do_ need to ensure that your PR titles do since we enforce squash-commits that default to the PR title and description as the git commit.


### PR DESCRIPTION
This PR adds linting for PR titles so that we can ensure that semantic release understands how to parse the final commit title.