### PR TITLE
fix: points self references to correct package name

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write 
     steps:
       - uses: aslafy-z/conventional-pr-title-action@v3
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,5 +3,8 @@
 ## Commits
 
 We use the `conventional-changelog-eslint` configuration.  While you don't need to ensure that individual commits follow that pattern, you _do_ need to ensure that your PR titles do since we enforce squash-commits that default to the PR title and description as the git commit.
+<<<<<<< HEAD
 
 Fake change
+=======
+>>>>>>> f537922 (chore: adds PR title linting (#1))

--- a/default.js
+++ b/default.js
@@ -6,8 +6,8 @@ const config = {
     "eslint:recommended",
     "airbnb-base",
     "plugin:unicorn/recommended",
-    "@tbhesswebber/eslint-plugin/components/comments",
-    "@tbhesswebber/eslint-plugin/components/imports",
+    "@tbhesswebber/eslint-config/components/comments",
+    "@tbhesswebber/eslint-config/components/imports",
   ],
   plugins: ["unicorn"],
   rules: {


### PR DESCRIPTION
Initially, this package had been called "plugin" instead of "config", which I ultimately decided to change to simplify things until I actually have a use-case for writing custom rules.  I never tweaked some self-references, which was then causing issues with how installations were resolving the config.