### PR TITLE
fix: import/extensions

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -23,6 +23,21 @@ const config = {
   },
   rules: {
     "import/consistent-type-specifier-style": ["error", "prefer-top-level"],
+    "import/extensions": [
+      "error",
+      "always",
+      {
+        "ignorePackages": true,
+        "pattern": {
+          "css": "always",
+          "js": "never",
+          "json": "always",
+          "jsx": "never",
+          "ts": "never",
+          "tsx": "never"
+        }
+      }
+    ]
     "@typescript-eslint/consistent-type-imports": [
       "error",
       { prefer: "type-imports", fixStyle: "separate-type-imports" },


### PR DESCRIPTION
I think the usage of the "import/typescript" within the typescript configuration is colliding with `import/extensions` - hopefully this fixes it.  Presumably, we want to eventually move over to leveraging overrides from the `import` config