### PR TITLE
fix(typescript): adds import resolver typescript

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,4 +6,7 @@ module.exports = {
   env: {
     es6: true,
   },
+  rules: {
+    "unicorn/prefer-module": "off",
+  },
 };

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint-config-airbnb": "^19.0.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-prettier": "^9.0.0",
+    "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-eslint-comments": "^3.0.0",
     "eslint-plugin-import": "^2.28.0",
     "eslint-plugin-jsx-a11y": "^6.7.1",

--- a/react.js
+++ b/react.js
@@ -20,7 +20,7 @@ const config = {
     ],
     "react/hook-use-state": ["warn", { allowDestructuredState: true }],
     "react/iframe-missing-sandbox": "error",
-    "react/jsx-filename-extension": ["error", {extensions: ["jsx", "tsx"]}],
+    "react/jsx-filename-extension": ["error", { extensions: ["jsx", "tsx"] }],
     "react/jsx-handler-names": [
       "error",
       {

--- a/typescript.js
+++ b/typescript.js
@@ -14,6 +14,13 @@ const config = {
   parserOptions: {
     project: true,
   },
+  settings: {
+    "import/resolver": {
+      typescript: {
+        alwaysTryTypes: true,
+      },
+    },
+  },
   rules: {
     "@typescript-eslint/consistent-type-imports": [
       "error",
@@ -225,6 +232,25 @@ const config = {
           regex: "^I[A-Z]",
           match: false,
         },
+      },
+      {
+        selector: [
+          "classProperty",
+          "objectLiteralProperty",
+          "typeProperty",
+          "classMethod",
+          "objectLiteralMethod",
+          "typeMethod",
+          "accessor",
+          "enumMember",
+        ],
+        format: null,
+        modifiers: ["requiresQuotes"],
+      },
+      {
+        selector: "import",
+        modifiers: "default",
+        format: ["StrictPascalCase", "strictCamelCase", "UPPER_CASE"],
       },
     ],
     "@typescript-eslint/no-require-imports": "error",


### PR DESCRIPTION
This PR adds `eslint-import-resolver-typescript` to the peer dependency list and configures it in the typescript configuration.  It also makes some small fixes to naming conventions to allow numeric-indexed object properties and allow any allowed casing to default imports.

closes #19 