### PR TITLE
fix: naming conventions

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -245,7 +245,7 @@ const config = {
       },
       {
         selector: "import",
-        modifiers: "default",
+        modifiers: ["default"],
         format: ["StrictPascalCase", "strictCamelCase", "UPPER_CASE"],
       },
     ],


### PR DESCRIPTION
Fixes default import naming convention `modifiers` property