### PR TITLE
fix: allow function and class usage before definition

### DIFF
--- a/default.js
+++ b/default.js
@@ -14,6 +14,12 @@ const config = {
     "unicorn/custom-error-definition": "error",
     "unicorn/no-keyword-prefix": "warn",
     "unicorn/no-null": "off",
+    "no-use-before-define": ["error", {
+        "functions": false,
+        "classes": false,
+        "variables": true,
+        "allowNamedExports": false
+    }],
   },
   overrides: [
     {


### PR DESCRIPTION
This PR configures the `use before define` rule to only target variables.  This allows people reviewing code to see the most important code at the top of the file rather than any "leaf nodes"