### PR TITLE
feat: improve react dx naming

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "ISC",
   "devDependencies": {
     "@semantic-release/npm": "^11.0.0",
-    "@tbhesswebber/eslint-config": "^1.0.1",
+    "@tbhesswebber/eslint-config": "^2.0.5",
     "conventional-changelog-eslint": "^5.0.0",
     "eslint": "^8.49.0",
     "eslint-config-airbnb-base": "^15.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,8 +41,8 @@ devDependencies:
     specifier: ^11.0.0
     version: 11.0.0(semantic-release@22.0.4)
   '@tbhesswebber/eslint-config':
-    specifier: ^1.0.1
-    version: 1.0.1(@typescript-eslint/eslint-plugin@6.7.2)(@typescript-eslint/parser@6.7.2)(eslint-config-airbnb-base@15.0.0)(eslint-config-airbnb@19.0.4)(eslint-plugin-eslint-comments@3.2.0)(eslint-plugin-import@2.28.1)(eslint-plugin-jsx-a11y@6.7.1)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react@7.33.2)(eslint-plugin-unicorn@48.0.1)(eslint@8.49.0)(typescript@5.2.2)
+    specifier: ^2.0.5
+    version: 2.0.5(@typescript-eslint/eslint-plugin@6.7.2)(@typescript-eslint/parser@6.7.2)(eslint-config-airbnb-base@15.0.0)(eslint-config-airbnb@19.0.4)(eslint-config-prettier@9.0.0)(eslint-import-resolver-typescript@3.6.1)(eslint-plugin-eslint-comments@3.2.0)(eslint-plugin-import@2.28.1)(eslint-plugin-jsx-a11y@6.7.1)(eslint-plugin-prettier@5.0.0)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react@7.33.2)(eslint-plugin-unicorn@48.0.1)(eslint@8.49.0)(prettier@3.0.3)(typescript@5.2.2)
   conventional-changelog-eslint:
     specifier: ^5.0.0
     version: 5.0.0
@@ -407,20 +407,24 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /@tbhesswebber/eslint-config@1.0.1(@typescript-eslint/eslint-plugin@6.7.2)(@typescript-eslint/parser@6.7.2)(eslint-config-airbnb-base@15.0.0)(eslint-config-airbnb@19.0.4)(eslint-plugin-eslint-comments@3.2.0)(eslint-plugin-import@2.28.1)(eslint-plugin-jsx-a11y@6.7.1)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react@7.33.2)(eslint-plugin-unicorn@48.0.1)(eslint@8.49.0)(typescript@5.2.2):
-    resolution: {integrity: sha512-RcIEE+zpRAY1LsgZlk5PDQte35tLyKaJjNcVi7R4dABJKW7GQ7fQ1ht69aHPzkj4O75MN1EyKj+RsSe6t/Y4cA==}
+  /@tbhesswebber/eslint-config@2.0.5(@typescript-eslint/eslint-plugin@6.7.2)(@typescript-eslint/parser@6.7.2)(eslint-config-airbnb-base@15.0.0)(eslint-config-airbnb@19.0.4)(eslint-config-prettier@9.0.0)(eslint-import-resolver-typescript@3.6.1)(eslint-plugin-eslint-comments@3.2.0)(eslint-plugin-import@2.28.1)(eslint-plugin-jsx-a11y@6.7.1)(eslint-plugin-prettier@5.0.0)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react@7.33.2)(eslint-plugin-unicorn@48.0.1)(eslint@8.49.0)(prettier@3.0.3)(typescript@5.2.2):
+    resolution: {integrity: sha512-/Aa3aUoObiXjR6tefIBwtP8/MjBLPew1JNmLzMhiQs7T2Gv1dyBD3dFezf6vnPBPYSjZYiroNXzVa4Og23gnHQ==}
     peerDependencies:
       '@typescript-eslint/eslint-plugin': ^6.0.0
       '@typescript-eslint/parser': ^6.0.0
       eslint: ^7.32.0 || ^8.2.0
       eslint-config-airbnb: ^19.0.0
       eslint-config-airbnb-base: ^15.0.0
+      eslint-config-prettier: ^9.0.0
+      eslint-import-resolver-typescript: ^3.6.1
       eslint-plugin-eslint-comments: ^3.0.0
       eslint-plugin-import: ^2.28.0
       eslint-plugin-jsx-a11y: ^6.7.1
+      eslint-plugin-prettier: ^5.0.0
       eslint-plugin-react: ^7.33.1
       eslint-plugin-react-hooks: ^4.6.0
       eslint-plugin-unicorn: ^48.0.0
+      prettier: ^3.0.0
       typescript: ^4.0.0 || ^5.0.0
     dependencies:
       '@typescript-eslint/eslint-plugin': 6.7.2(@typescript-eslint/parser@6.7.2)(eslint@8.49.0)(typescript@5.2.2)
@@ -428,12 +432,16 @@ packages:
       eslint: 8.49.0
       eslint-config-airbnb: 19.0.4(eslint-plugin-import@2.28.1)(eslint-plugin-jsx-a11y@6.7.1)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react@7.33.2)(eslint@8.49.0)
       eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.28.1)(eslint@8.49.0)
+      eslint-config-prettier: 9.0.0(eslint@8.49.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.7.2)(eslint-plugin-import@2.28.1)(eslint@8.49.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.49.0)
       eslint-plugin-import: 2.28.1(@typescript-eslint/parser@6.7.2)(eslint-import-resolver-typescript@3.6.1)(eslint@8.49.0)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.49.0)
+      eslint-plugin-prettier: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.0.3)
       eslint-plugin-react: 7.33.2(eslint@8.49.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.49.0)
       eslint-plugin-unicorn: 48.0.1(eslint@8.49.0)
+      prettier: 3.0.3
       typescript: 5.2.2
     dev: true
 

--- a/react.js
+++ b/react.js
@@ -11,6 +11,17 @@ const config = {
   ],
   plugins: ["react", "react-hooks"],
   rules: {
+    "unicorn/prevent-abbreviations": [
+      "error",
+      {
+        allowList: {
+          prop: true,
+          Prop: true,
+          props: true,
+          Props: true,
+        },
+      },
+    ],
     "react/function-component-definition": [
       "error",
       {

--- a/typescript.js
+++ b/typescript.js
@@ -1,3 +1,76 @@
+const namingConventions = [
+  {
+    selector: "default",
+    format: ["strictCamelCase"],
+    leadingUnderscore: "allow",
+    trailingUnderscore: "allow",
+  },
+  {
+    selector: "function",
+    format: ["StrictPascalCase", "strictCamelCase"],
+  },
+  {
+    selector: "enumMember",
+    format: ["StrictPascalCase", "UPPER_CASE"],
+    leadingUnderscore: "allow",
+    trailingUnderscore: "allow",
+  },
+  {
+    selector: "variable",
+    format: ["strictCamelCase"],
+    leadingUnderscore: "allow",
+    trailingUnderscore: "allow",
+  },
+  {
+    selector: "variable",
+    format: ["strictCamelCase", "UPPER_CASE"],
+    modifiers: ["const"],
+  },
+  {
+    selector: "variable",
+    types: ["boolean"],
+    format: ["StrictPascalCase"],
+    prefix: ["is", "should", "has", "can", "did", "will"],
+  },
+
+  {
+    selector: "typeLike",
+    format: ["StrictPascalCase"],
+  },
+  {
+    selector: "typeParameter",
+    format: ["PascalCase"],
+    prefix: ["T"],
+  },
+  {
+    selector: "interface",
+    format: ["PascalCase"],
+    custom: {
+      regex: "^I[A-Z]",
+      match: false,
+    },
+  },
+  {
+    selector: [
+      "classProperty",
+      "objectLiteralProperty",
+      "typeProperty",
+      "classMethod",
+      "objectLiteralMethod",
+      "typeMethod",
+      "accessor",
+      "enumMember",
+    ],
+    format: null,
+    modifiers: ["requiresQuotes"],
+  },
+  {
+    selector: "import",
+    modifiers: ["default"],
+    format: ["StrictPascalCase", "strictCamelCase", "UPPER_CASE"],
+  },
+];
+
 /**
  * @type import("eslint-define-config").ESLintConfig
  */
@@ -15,7 +88,7 @@ const config = {
     project: true,
   },
   settings: {
-    "import/resolver": "typescript"
+    "import/resolver": "typescript",
   },
   rules: {
     "@typescript-eslint/consistent-type-imports": [
@@ -180,75 +253,7 @@ const config = {
         allowTypedFunctionExpressions: false,
       },
     ],
-    "@typescript-eslint/naming-convention": [
-      "warn",
-
-      {
-        selector: "default",
-        format: ["strictCamelCase"],
-        leadingUnderscore: "allow",
-        trailingUnderscore: "allow",
-      },
-      {
-        selector: "function",
-        format: ["StrictPascalCase", "strictCamelCase"],
-      },
-      {
-        selector: "enumMember",
-        format: ["StrictPascalCase", "UPPER_CASE"],
-        leadingUnderscore: "allow",
-        trailingUnderscore: "allow",
-      },
-      {
-        selector: "variable",
-        format: ["strictCamelCase", "UPPER_CASE"],
-        leadingUnderscore: "allow",
-        trailingUnderscore: "allow",
-      },
-      {
-        selector: "variable",
-        types: ["boolean"],
-        format: ["StrictPascalCase"],
-        prefix: ["is", "should", "has", "can", "did", "will"],
-      },
-
-      {
-        selector: "typeLike",
-        format: ["StrictPascalCase"],
-      },
-      {
-        selector: "typeParameter",
-        format: ["PascalCase"],
-        prefix: ["T"],
-      },
-      {
-        selector: "interface",
-        format: ["PascalCase"],
-        custom: {
-          regex: "^I[A-Z]",
-          match: false,
-        },
-      },
-      {
-        selector: [
-          "classProperty",
-          "objectLiteralProperty",
-          "typeProperty",
-          "classMethod",
-          "objectLiteralMethod",
-          "typeMethod",
-          "accessor",
-          "enumMember",
-        ],
-        format: null,
-        modifiers: ["requiresQuotes"],
-      },
-      {
-        selector: "import",
-        modifiers: ["default"],
-        format: ["StrictPascalCase", "strictCamelCase", "UPPER_CASE"],
-      },
-    ],
+    "@typescript-eslint/naming-convention": ["warn", ...namingConventions],
     "@typescript-eslint/no-require-imports": "error",
     "@typescript-eslint/prefer-regexp-exec": "error",
     "@typescript-eslint/promise-function-async": "error",
@@ -287,6 +292,21 @@ const config = {
     "no-return-await": "off",
     "@typescript-eslint/return-await": ["error", "in-try-catch"],
   },
+  overrides: [
+    {
+      files: ["**/*.tsx", "**/*/jsx"],
+      rules: {
+        "@typescript-eslint/naming-convention": [
+          "warn",
+          ...namingConventions,
+          {
+            selector: ["variable"],
+            format: ["StrictPascalCase", "strictCamelCase"],
+          },
+        ],
+      },
+    },
+  ],
 };
 
 module.exports = config;


### PR DESCRIPTION
This PR updates how names are constructed in React.  In any `(j|t)sx` file, you can now use PascalCase naming conventions and can use the word `props` throughout the codebase.