### PR TITLE
chore: update .releaserc

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -7,30 +7,42 @@
         "releaseRules": [
           {
             "tag": "breaking",
+            "scope": "*"
             "release": "major"
           },
           {
+            "tag": "feat",
+            "scope": "*"
+            "release": "minor"
+          },
+          {
             "tag": "fix",
+            "scope": "*"
             "release": "patch"
           },
           {
             "tag": "update",
+            "scope": "*"
             "release": "minor"
           },
           {
             "tag": "new",
+            "scope": "*"
             "release": "minor"
           },
           {
             "tag": "breaking",
+            "scope": "*"
             "release": "major"
           },
           {
             "tag": "docs",
+            "scope": "*"
             "release": "patch"
           },
           {
             "tag": "upgrade",
+            "scope": "*"
             "release": "patch"
           }
         ]


### PR DESCRIPTION
This PR (hopefully) allows commits with scopes and with `feat` type to trigger releases.