### PR TITLE
fix(typescript): ensures identifiers only match a single selector

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -17,12 +17,6 @@ const namingConventions = [
   },
   {
     selector: "variable",
-    format: ["strictCamelCase"],
-    leadingUnderscore: "allow",
-    trailingUnderscore: "allow",
-  },
-  {
-    selector: "variable",
     format: ["strictCamelCase", "UPPER_CASE"],
     modifiers: ["const"],
   },
@@ -253,7 +247,16 @@ const config = {
         allowTypedFunctionExpressions: false,
       },
     ],
-    "@typescript-eslint/naming-convention": ["warn", ...namingConventions],
+    "@typescript-eslint/naming-convention": [
+      "warn",
+      ...namingConventions,
+      {
+        selector: "variable",
+        format: ["strictCamelCase"],
+        leadingUnderscore: "allow",
+        trailingUnderscore: "allow",
+      },
+    ],
     "@typescript-eslint/no-require-imports": "error",
     "@typescript-eslint/prefer-regexp-exec": "error",
     "@typescript-eslint/promise-function-async": "error",


### PR DESCRIPTION
According to this section of the docs, an identifier is only allowed to match one individual selector (may match many groups, but only one individual).  This fixes the problem such that react and non-react code have different rules for variables.