### PR TITLE
fix(react): adds "ref" to allowed abbreviations

### DIFF
--- a/react.js
+++ b/react.js
@@ -19,6 +19,7 @@ const config = {
           Prop: true,
           props: true,
           Props: true,
+          ref: true,
         },
       },
     ],


### PR DESCRIPTION
The term "ref" is a colloquialism so common in frontend frameworks that not allowing the term to be used encourages the use of `eslint-disable` comments.